### PR TITLE
Relaxed polymorphic variant error type constraint

### DIFF
--- a/src/imandra_http_api_client.ml
+++ b/src/imandra_http_api_client.ml
@@ -33,7 +33,7 @@ let default_headers (c : Config.t) =
 let make_body enc x =
   Decoders_yojson.Basic.Encode.encode_string enc x |> Cohttp_lwt.Body.of_string
 
-let read_response dec s =
+let read_response dec s=
   match
     Decoders_yojson.Basic.Decode.decode_string (D.Response.with_capture dec) s
   with
@@ -48,7 +48,7 @@ let read_error s =
   | Error e -> Error (`Error_decoding_response e)
 
 let read (dec : 'a Decoders_yojson.Basic.Decode.decoder) (resp, body) :
-    ('a Api.Response.with_capture, error) Lwt_result.t =
+    ('a Api.Response.with_capture, [> error ]) Lwt_result.t =
   let open Lwt.Syntax in
   let* body = Cohttp_lwt.Body.to_string body in
   let status = Cohttp.Response.status resp in

--- a/src/imandra_http_api_client.mli
+++ b/src/imandra_http_api_client.mli
@@ -164,46 +164,46 @@ val read_error :
 val read :
   'a Decoders_yojson.Basic.Decode.decoder ->
   Cohttp.Response.t * Cohttp_lwt.Body.t ->
-  ('a Api.Response.with_capture, error) Lwt_result.t
+  ('a Api.Response.with_capture, [> error] ) Lwt_result.t
 
 val eval :
   Config.t ->
   Api.Request.eval_req_src ->
-  (Api.Response.eval_result Api.Response.with_capture, error) result Lwt.t
+  (Api.Response.eval_result Api.Response.with_capture, [> error]) result Lwt.t
 
 val get_history :
-  Config.t -> (string Api.Response.with_capture, error) result Lwt.t
+  Config.t -> (string Api.Response.with_capture, [> error]) result Lwt.t
 
 val get_status :
-  Config.t -> (string Api.Response.with_capture, error) result Lwt.t
+  Config.t -> (string Api.Response.with_capture, [> error]) result Lwt.t
 
 val instance_by_name :
   Config.t ->
   Api.Request.instance_req_name ->
-  (Api.Response.instance_result Api.Response.with_capture, error) result Lwt.t
+  (Api.Response.instance_result Api.Response.with_capture, [> error]) result Lwt.t
 
 val instance_by_src :
   Config.t ->
   Api.Request.instance_req_src ->
-  (Api.Response.instance_result Api.Response.with_capture, error) result Lwt.t
+  (Api.Response.instance_result Api.Response.with_capture, [> error]) result Lwt.t
 
 val reset :
-  Config.t -> unit -> (unit Api.Response.with_capture, error) result Lwt.t
+  Config.t -> unit -> (unit Api.Response.with_capture, [> error]) result Lwt.t
 
 val shutdown :
-  Config.t -> unit -> (string Api.Response.with_capture, error) result Lwt.t
+  Config.t -> unit -> (string Api.Response.with_capture, [> error]) result Lwt.t
 
 val verify_by_name :
   Config.t ->
   Api.Request.verify_req_name ->
-  (Api.Response.verify_result Api.Response.with_capture, error) result Lwt.t
+  (Api.Response.verify_result Api.Response.with_capture, [> error]) result Lwt.t
 
 val verify_by_src :
   Config.t ->
   Api.Request.verify_req_src ->
-  (Api.Response.verify_result Api.Response.with_capture, error) result Lwt.t
+  (Api.Response.verify_result Api.Response.with_capture, [> error]) result Lwt.t
 
 val decompose :
   Config.t ->
   Api.Request.decomp_req_src ->
-  (Yojson.Basic.t Api.Response.decompose_result Api.Response.with_capture, error) result Lwt.t
+  (Yojson.Basic.t Api.Response.decompose_result Api.Response.with_capture, [> error]) result Lwt.t


### PR DESCRIPTION
Following this article  https://keleshev.com/composable-error-handling-in-ocaml and discussion in #ocaml channel. 
I propose to use approach `D. Result type with polymorphic variants for errors` for error handling.


